### PR TITLE
policy - have conditions support vars

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -1239,6 +1239,10 @@ class Policy:
 
         # Update ourselves in place
         self.data = updated
+
+        # NOTE rebuild the policy conditions base on the new self.data
+        self.conditions = PolicyConditions(self, self.data)
+
         # Reload filters/actions using updated data, we keep a reference
         # for some compatiblity preservation work.
         m = self.resource_manager


### PR DESCRIPTION
in order to support the holiday break conditions
```yaml
or:
  - type: value
    key: now
    op: less-than
    value_type: date
    value: "{holiday_break_start}"
  - type: value
    key: now
    op: greater-than
    value_type: date
    value: "{holiday_break_end}"
```