### PR TITLE
support - res should only use us-east-1 or gov one

### DIFF
--- a/c7n/resources/support.py
+++ b/c7n/resources/support.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, TypeInfo
+from c7n.utils import local_session, get_support_region
 
 
 @resources.register('support-case')
@@ -17,3 +18,7 @@ class SupportCase(QueryResourceManager):
         name = 'displayId'
         date = 'timeCreated'
         arn = False
+
+    def get_client(self):
+        region = get_support_region(self)
+        return local_session(self.session_factory).client('support', region_name=region)


### PR DESCRIPTION
contiue https://github.com/cloud-custodian/cloud-custodian/pull/7220 aws - get support region by partition, dont use region from manager