### PR TITLE
PE-8122: Set default Jira ticket to Story

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/jira_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/jira_delivery.py
@@ -65,7 +65,7 @@ class JiraDelivery:
                         "slack_default",
                         self.config["templates_folders"],
                     ),
-                    "issuetype": {"name": jira_conf.get("issuetype", "Task")},
+                    "issuetype": {"name": jira_conf.get("issuetype", "Story")},
                     "priority": {"name": jira_conf.get("priority", "Medium")},
                 }
             )


### PR DESCRIPTION
Setting default Jira ticket to story.

This is only used by NCA - and has been applied directly to the Lambda function already, and some rudimentary testing has confirmed it's working for NCA. 