### PR TITLE
PE-17024: Fix Infracost dependency bug

### DIFF
--- a/c7n/filters/cost.py
+++ b/c7n/filters/cost.py
@@ -75,7 +75,7 @@ class Infracost(Filter):
             verify=True,
             retries=5,
         )
-        client = Client(transport=transport, fetch_schema_from_transport=True)
+        client = Client(transport=transport, fetch_schema_from_transport=False)
         query = gql(self.get_query())
         return [r for r in resources if self.process_resource(r, client, query)]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ boto3 = "^1.12.31"
 jsonschema = ">=3.0.0"
 argcomplete = ">=1.12.3"
 gql = {extras = ["requests"], version = "^3.4.0"}
+graphql-core = ">=3.2,<3.3"
 python-dateutil = "^2.8.2"
 pyyaml = ">=5.4.0"
 tabulate = "^0.8.6"


### PR DESCRIPTION
This pull request makes a minor dependency update and a small code change to the cost filter logic. The main change disables schema fetching when initializing the GraphQL client, and a new dependency is added to ensure compatibility.

Dependency management:

* Added the `graphql-core` package with version constraint `>=3.2,<3.3` to `pyproject.toml` to ensure compatibility with the `gql` library.

GraphQL client initialization:

* Changed the `Client` initialization in `c7n/filters/cost.py` to set `fetch_schema_from_transport=False`, which disables automatic schema fetching, likely improving performance or avoiding compatibility issues.